### PR TITLE
Fixes function calls so that if they return void they do not build an assignment.

### DIFF
--- a/sham-lib/sham/ast/simple.rkt
+++ b/sham-lib/sham/ast/simple.rkt
@@ -36,6 +36,9 @@
 (define (fl64 v) (sham:ast:expr:const:fl v f64))
 
 (define tvoid (sham:ast:type:ref 'void))
+(define (tvoid? x)
+  (and (sham:ast:type:ref? x)
+       (eq? (sham:ast:type:ref-to x) 'void)))
 
 (define dmodule sham:def:module)
 (define dfunction sham:def:function)


### PR DESCRIPTION
```
call void @printf(i64* bitcast ([11 x i8]* @str1667 to i64*))
```