### PR TITLE
remove automatic dereference of external globals

### DIFF
--- a/sham-lib/sham/ir/builder.rkt
+++ b/sham-lib/sham/ir/builder.rkt
@@ -278,7 +278,7 @@
                            (build-llvm-type t env)
                            (symbol->string sym)))
           (add-ffi-mapping! sym (cons lib-id value))
-          (LLVMBuildLoad builder value (symbol->string sym))]
+          value]
          [(sham:ast:expr:global md sym) (env-value-ref (env-lookup sym env))]
          [else (error "unknown experssion while compiling sham" e)])))
 


### PR DESCRIPTION
Currently there is no way of writing the following code because external variables are always dereferenced. The intrinsic `store!` expects an expression argument that is a pointer, but the reference `counter` is loaded, instead of being passed on to `store!`.
```racket
(store! (add (external #f 'counter i64) (ui 1)) (external #f 'counter i64))
```
My suggested fix is to require the user to load external global variables, and not automatically dereference the external global variable.

```racket
(store! (add (external #f 'counter i64) (ui 1)) (load (external #f 'counter i64)))
```
